### PR TITLE
Install Playwright browser in Pages CI

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -24,6 +24,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npx playwright install --with-deps chromium
       - run: npm run verify
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Install Chromium and system dependencies before `npm run verify` so the GitHub Pages quality gate works on fresh runners.