### PR TITLE
Move reading progress into article TOC

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -24,6 +24,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npx playwright install --with-deps chromium
       - run: npm run verify
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -47,14 +47,6 @@ const toc = headings.filter((heading) => heading.depth >= 2 && heading.depth <= 
               </time>
             )
           }<span>{readingTime(article.body)} min read</span>
-        </div><div
-          class="reading-status"
-          data-reading-minutes={readingTime(article.body)}
-          aria-live="off"
-        >
-          <span>Estimated reading time: {readingTime(article.body)} min</span><span
-            data-reading-progress>{readingTime(article.body)} min left · 0% read</span
-          >
         </div><div class="tag-list">
           {
             article.data.tags.map((tag) => (
@@ -82,6 +74,14 @@ const toc = headings.filter((heading) => heading.depth >= 2 && heading.depth <= 
       toc.length > 0 && (
         <aside class="toc" aria-label="On this page">
           <>
+            <div
+              class="reading-status"
+              data-reading-minutes={readingTime(article.body)}
+              aria-live="off"
+            >
+              <span>Estimated reading time: {readingTime(article.body)} min</span>
+              <span data-reading-progress>{readingTime(article.body)} min left · 0% read</span>
+            </div>
             <p class="eyebrow">On this page</p>
             <ul>
               {toc.map((heading) => (
@@ -147,9 +147,16 @@ const toc = headings.filter((heading) => heading.depth >= 2 && heading.depth <= 
   );
   const updateReadingStatus = () => {
     if (!content || !readingStatus) return;
-    const rect = content.getBoundingClientRect();
-    const total = Math.max(1, content.scrollHeight - window.innerHeight * 0.55);
-    const progress = Math.min(1, Math.max(0, (window.innerHeight * 0.2 - rect.top) / total));
+    const contentTop = content.getBoundingClientRect().top + window.scrollY;
+    const contentEnd = contentTop + content.scrollHeight - window.innerHeight * 0.58;
+    const progress = Math.min(
+      1,
+      Math.max(
+        0,
+        (window.scrollY + window.innerHeight * 0.22 - contentTop) /
+          Math.max(1, contentEnd - contentTop),
+      ),
+    );
     const left = Math.max(0, Math.ceil(readingMinutes * (1 - progress)));
     readingStatus.textContent = `${left} min left · ${Math.round(progress * 100)}% read`;
   };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -351,7 +351,8 @@ h1 {
 }
 .reading-status {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 1rem;
   color: var(--secondary);
   background: var(--surface);
@@ -481,6 +482,11 @@ h1 {
   top: 96px;
   padding-top: 4rem;
 }
+.toc .reading-status {
+  margin-bottom: 1.5rem;
+  gap: 0.25rem;
+  width: 100%;
+}
 .toc ul {
   list-style: none;
   padding: 0;
@@ -575,6 +581,14 @@ h1 {
     padding-top: 3.5rem;
   }
   .toc {
+    display: block;
+    position: static;
+    order: -1;
+    padding-top: 0;
+    margin-bottom: 2rem;
+  }
+  .toc > .eyebrow,
+  .toc > ul {
     display: none;
   }
   .article-header {
@@ -597,10 +611,6 @@ h1 {
   }
   .article-content {
     font-size: 1rem;
-  }
-  .reading-status {
-    display: grid;
-    gap: 0.2rem;
   }
   .topic-directory {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Move the reading-time widget into the sticky article TOC and calculate remaining minutes and percentage from the real article content bounds while scrolling. Keep the widget visible above the content on mobile.