### PR TITLE
Add legal pages and sync site branding

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -70,7 +70,9 @@ const graph = [websiteJsonLd, personJsonLd, ...(Array.isArray(jsonLd) ? jsonLd :
       </div><nav aria-label="Footer navigation">
         <a href="/rss.xml">RSS</a><a href="https://github.com/AlTosterino">GitHub</a><a
           href="https://rozycki.dev">rozycki.dev</a
-        ><a href="https://www.linkedin.com/in/daniel-rozycki/">LinkedIn</a>
+        ><a href="https://www.linkedin.com/in/daniel-rozycki/">LinkedIn</a><a href="/privacy/"
+          >Privacy Policy</a
+        ><a href="/terms/">Terms</a>
       </nav><small>© {new Date().getFullYear()}</small>
     </footer>
   </body>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,121 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Privacy Policy — toastin.it"
+  description="Privacy policy for toastin.it, including hosting, local storage and contact information."
+  canonical="/privacy/"
+>
+  <article class="wrap page-intro narrow legal-page">
+    <p class="eyebrow">Legal</p>
+    <h1>Privacy Policy</h1>
+    <p class="lead">Last updated: August 24, 2026.</p>
+
+    <h2>1. Data controller</h2>
+    <p>The controller responsible for personal data connected with toastin.it is:</p>
+    <address>
+      <strong>Daniel Różycki</strong><br />
+      NIP: 7262679953<br />
+      REGON: 385332519<br />
+      ul. Grabieniec 17A/87<br />
+      91-140 Łódź, Poland<br />
+      Email: <a href="mailto:kontakt@rozycki.dev">kontakt@rozycki.dev</a>
+    </address>
+
+    <h2>2. What data may be processed</h2>
+    <p>
+      You do not need to provide personal data to read toastin.it. When the website is delivered,
+      technical data may be processed automatically, including IP address, request date and time,
+      browser or device information and server or security logs.
+    </p>
+    <p>
+      If you contact me by email, I may process the information contained in your message,
+      including your email address and any information you choose to provide.
+    </p>
+
+    <h2>3. Purposes and legal bases</h2>
+    <p>Personal data may be processed for the following purposes:</p>
+    <ul>
+      <li>operating, securing and troubleshooting the website — Article 6(1)(f) GDPR;</li>
+      <li>responding to correspondence — Article 6(1)(f) GDPR;</li>
+      <li>
+        taking steps at your request before entering into a contract, where a message concerns
+        potential cooperation — Article 6(1)(b) GDPR;
+      </li>
+      <li>
+        complying with legal obligations and establishing, pursuing or defending legal claims where
+        necessary.
+      </li>
+    </ul>
+
+    <h2>4. Hosting and technical providers</h2>
+    <p>
+      toastin.it is built and hosted using GitHub Pages and GitHub Actions infrastructure provided
+      by GitHub. GitHub may process technical information required to deliver and secure the site,
+      including IP addresses and request or security logs, in accordance with its own privacy terms
+      and applicable data-protection safeguards.
+    </p>
+    <p>
+      Data may also be processed by providers of email or technical services where this is necessary
+      to provide those services. I do not sell personal data or provide it to third parties for
+      advertising purposes.
+    </p>
+
+    <h2>5. Cookies, local storage and analytics</h2>
+    <p>
+      toastin.it does not use Google Analytics, Meta Pixel, Microsoft Clarity or comparable
+      advertising or behavioural analytics tools, and the website does not set first-party cookies
+      for analytics or advertising.
+    </p>
+    <p>
+      When you manually choose the light or dark theme, the preference is stored in your browser's
+      <code>localStorage</code> under the key <code>theme</code>. This value is used only to remember
+      the interface theme you requested. It is not used for identification, profiling, advertising
+      or analytics. You can remove it at any time by clearing site data in your browser.
+    </p>
+    <p>The hosting provider may use technical mechanisms necessary to deliver or secure the service.</p>
+
+    <h2>6. External links</h2>
+    <p>
+      The website contains links to external services such as GitHub, LinkedIn and rozycki.dev.
+      After you follow an external link, data processing is governed by the privacy rules of the
+      relevant external service.
+    </p>
+
+    <h2>7. Retention</h2>
+    <p>
+      Email correspondence is retained for as long as necessary to deal with the relevant matter
+      and, where appropriate, for a period required to comply with legal obligations or protect
+      against possible claims.
+    </p>
+    <p>
+      Technical logs are retained according to the configuration and retention policies of the
+      infrastructure provider for the period necessary to operate and secure the website.
+    </p>
+
+    <h2>8. Your rights</h2>
+    <p>
+      Subject to the conditions provided by the GDPR, you may request access to your personal data,
+      rectification, erasure, restriction of processing or data portability where applicable. You
+      may also object to processing based on legitimate interests.
+    </p>
+    <p>
+      To exercise these rights, contact <a href="mailto:kontakt@rozycki.dev">kontakt@rozycki.dev</a>.
+      You also have the right to lodge a complaint with the competent supervisory authority. In
+      Poland this is the President of the Personal Data Protection Office (UODO).
+    </p>
+
+    <h2>9. Voluntary provision of data</h2>
+    <p>
+      Providing personal data by email is voluntary, although some information may be necessary for
+      me to answer your message or discuss potential cooperation.
+    </p>
+
+    <h2>10. Changes to this policy</h2>
+    <p>
+      This policy may be updated when the website, its providers or applicable law changes. The
+      current version will always be available at this address.
+    </p>
+  </article>
+</BaseLayout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,103 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Terms of Use — toastin.it"
+  description="Terms governing the use of toastin.it."
+  canonical="/terms/"
+>
+  <article class="wrap page-intro narrow legal-page">
+    <p class="eyebrow">Legal</p>
+    <h1>Terms of Use</h1>
+    <p class="lead">Last updated: August 24, 2026.</p>
+
+    <h2>1. Website operator</h2>
+    <p>toastin.it is operated by:</p>
+    <address>
+      <strong>Daniel Różycki</strong><br />
+      NIP: 7262679953<br />
+      REGON: 385332519<br />
+      ul. Grabieniec 17A/87<br />
+      91-140 Łódź, Poland<br />
+      Email: <a href="mailto:kontakt@rozycki.dev">kontakt@rozycki.dev</a>
+    </address>
+
+    <h2>2. Purpose of the website</h2>
+    <p>
+      toastin.it is a technical blog containing articles, notes and other materials about software
+      engineering, software architecture, Python, distributed systems, AI-assisted development and
+      related topics.
+    </p>
+    <p>
+      The website is provided for informational and educational purposes. It does not constitute
+      legal, tax, financial, security or other regulated professional advice.
+    </p>
+
+    <h2>3. Technical requirements</h2>
+    <p>
+      To use the website you need an internet connection and a current web browser capable of
+      displaying standard HTML, CSS and JavaScript. Some optional features, such as search, theme
+      selection or interactive diagrams, may require JavaScript.
+    </p>
+
+    <h2>4. Availability and changes</h2>
+    <p>
+      I may update, remove or reorganise content and website functionality at any time. I do not
+      guarantee uninterrupted availability of the website or that every article will remain current
+      indefinitely.
+    </p>
+
+    <h2>5. Content and responsibility</h2>
+    <p>
+      I aim to publish accurate and useful technical material, but software, libraries, services and
+      best practices change over time. You are responsible for verifying whether information is
+      appropriate for your specific system, environment and risk profile before relying on it.
+    </p>
+    <p>
+      To the extent permitted by applicable law, I am not responsible for loss resulting solely from
+      decisions made on the basis of general informational content published on the website.
+    </p>
+
+    <h2>6. Intellectual property</h2>
+    <p>
+      Unless a particular article or asset explicitly states otherwise, original articles, text,
+      diagrams and other editorial content published on toastin.it are protected by applicable
+      copyright law. Quotation and other permitted uses remain available to the extent allowed by
+      law.
+    </p>
+    <p>
+      Source code of the website may be made available separately under the licence specified in its
+      public source repository. A software licence in the repository does not automatically grant a
+      licence to reuse the editorial content of the blog unless expressly stated.
+    </p>
+
+    <h2>7. External links</h2>
+    <p>
+      Articles may link to third-party websites, documentation, repositories and services. Those
+      resources are operated independently, and I am not responsible for their availability,
+      content, security or privacy practices.
+    </p>
+
+    <h2>8. Prohibited use</h2>
+    <p>
+      You must not intentionally interfere with the operation or security of the website, attempt to
+      bypass access controls, or use automated traffic in a way that materially disrupts service for
+      other users.
+    </p>
+
+    <h2>9. Privacy</h2>
+    <p>
+      Information about personal-data processing, hosting and local browser storage is available in
+      the <a href="/privacy/">Privacy Policy</a>.
+    </p>
+
+    <h2>10. Contact and changes to these terms</h2>
+    <p>
+      Questions about these terms can be sent to
+      <a href="mailto:kontakt@rozycki.dev">kontakt@rozycki.dev</a>. These terms may be updated when
+      the website, its functionality or applicable law changes. The current version is published at
+      this address.
+    </p>
+  </article>
+</BaseLayout>

--- a/tests/site.spec.ts
+++ b/tests/site.spec.ts
@@ -47,6 +47,7 @@ test('public pages expose canonical SEO metadata and structured data', async ({ 
     'href',
     'https://toastin.it/',
   );
+  await expect(page.locator('link[rel="icon"]')).toHaveAttribute('href', '/favicon.svg');
   await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
     'content',
     /\/og\/home\.png$/,
@@ -77,6 +78,23 @@ test('public pages expose canonical SEO metadata and structured data', async ({ 
 
   await page.goto('/search/');
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'noindex,follow');
+});
+
+test('legal pages render and are linked from the footer', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('.site-footer a[href="/privacy/"]')).toHaveText('Privacy Policy');
+  await expect(page.locator('.site-footer a[href="/terms/"]')).toHaveText('Terms');
+
+  await page.goto('/privacy/');
+  await expect(page.locator('h1')).toHaveText('Privacy Policy');
+  await expect(page.locator('main')).toContainText('NIP: 7262679953');
+  await expect(page.locator('main')).toContainText('REGON: 385332519');
+  await expect(page.locator('main')).toContainText('localStorage');
+
+  await page.goto('/terms/');
+  await expect(page.locator('h1')).toHaveText('Terms of Use');
+  await expect(page.locator('main')).toContainText('NIP: 7262679953');
+  await expect(page.locator('a[href="/privacy/"]')).toHaveCount(2);
 });
 
 test('mobile navigation is keyboard and button accessible', async ({ page }) => {


### PR DESCRIPTION
Adds Privacy Policy and Terms of Use tailored to the actual toastin.it stack (GitHub Pages, no analytics, localStorage theme preference), links both pages from the footer, and adds Playwright coverage for legal pages and favicon usage. The toastin.it favicon was verified to be byte-for-byte identical to rozycki.dev (same Git blob SHA), so no artificial favicon content change was made.